### PR TITLE
The LEVITATION effect was forgotten

### DIFF
--- a/src/veroxcode/Guardian/Checks/Movement/Fly.php
+++ b/src/veroxcode/Guardian/Checks/Movement/Fly.php
@@ -67,6 +67,12 @@ class Fly extends Check
             return;
         }
 
+        $LEVITATION = $effects->get(VanillaEffects::LEVITATION());
+        if ($LEVITATION != null){
+            $user->setWaitForGround(true);
+            return;
+        }
+
         if ($player->getWorld()->getBlock($player->getPosition()->add(0, $yMotion, 0))->isSolid() || $user->isWaitForGround()){
             return;
         }


### PR DESCRIPTION
You might ask why I didn't define it like jump boost! Because in plugin writing, this effect can be defined negatively, so if I wanted to not change the check definition, it would cause a crash!

For example, in HangGlider plugins, this negative face effect is defined!